### PR TITLE
自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,4 +65,36 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     })
   });
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    console.log(last_message_id)
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        var msg = '.messages';
+        $.each(messages, function(i,message) {
+          insertHTML += buildHTML(message)
+          console.log(message);
+        });
+        message(insertHTML,msg);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages,7000);
 });
+
+function message(insertHTML,msg) {
+  $(msg).append(insertHTML);
+  $(msg).animate({ scrollTop: $(msg)[0]});
+};

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -92,6 +92,7 @@ $(function(){
   };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {
   setInterval(reloadMessages,7000);
+  }
 });
 
 function message(insertHTML,msg) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -67,7 +67,6 @@ $(function(){
   });
   var reloadMessages = function() {
     var last_message_id = $('.message:last').data("message-id");
-    console.log(last_message_id)
     $.ajax({
       url: "api/messages",
       type: 'get',
@@ -80,7 +79,6 @@ $(function(){
         var msg = '.messages';
         $.each(messages, function(i,message) {
           insertHTML += buildHTML(message)
-          console.log(message);
         });
         message(insertHTML,msg);
         $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :groups, only: [:new, :create, :edit, :update]
   resources :groups, only:[:index, :new, :create, :edit, :update] do
     resources :messages, only:[:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
7秒毎に更新内容を確認、非同期でメッセージ表示を最新に更新する機能を追加する。
# Why
メッセージのやり取りをする中で、相手のメッセージ受け取るために都度ページを更新するのは現実的では無い。
そこで非同期でのメッセージの確認を行う処理を追加した。

動作のキャプチャは以下のリンクから
https://gyazo.com/91851025a51ff4fec8f65fc00912a617
